### PR TITLE
Dev 0.2.2

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # ohsome (development version)
 
+* On load, the package issues an informative message instead of a warning upon 
+an error status code from the ohsome API.
+
 # ohsome 0.2.1
 
 * Package CITATION file calls `bibentry()` instead of old-style `citEntry()`.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,10 @@
 # ohsome (development version)
 
-* On load, the package issues an informative message instead of a warning upon 
-an error status code from the ohsome API.
+* On attach, the package now issues an informative startup message instead of a
+warning if it could not retrieve metadata information from the ohsome API.
+* Vignette code chunks do not evaluate on CRAN to avoid errors when internet
+resources are temporally unavailable
+* Fixed tests to use suggested packages conditionally
 
 # ohsome 0.2.1
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -13,18 +13,18 @@
 			envir = parent.env(environment())
 		)
 		},
-		error = function(e) {
-			packageStartupMessage(
-				"Could not retrieve metadata from ohsome API.",
-				"\nPlease check your internet connection and try to run ",
-				"ohsome_get_metadata()"
-			)
-		}
+		error = function(e) return(TRUE)
 	)
 }
 
 .onAttach <- function(libname, pkgname) {
 	if(exists("ohsome_metadata", where = parent.env(environment()))) {
 		packageStartupMessage(create_metadata_message(ohsome_metadata))
+	} else {
+		packageStartupMessage(
+			"Could not retrieve metadata from ohsome API.",
+			"\nPlease check your internet connection and try to run ",
+			"ohsome_get_metadata()"
+		)
 	}
 }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -14,7 +14,7 @@
 		)
 		},
 		error = function(e) {
-			warning(
+			message(
 				"Could not retrieve metadata from ohsome API.",
 				"\nPlease check your internet connection and try to run ",
 				"ohsome_get_metadata()",

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -14,11 +14,10 @@
 		)
 		},
 		error = function(e) {
-			message(
+			packageStartupMessage(
 				"Could not retrieve metadata from ohsome API.",
 				"\nPlease check your internet connection and try to run ",
-				"ohsome_get_metadata()",
-				call. = FALSE
+				"ohsome_get_metadata()"
 			)
 		}
 	)

--- a/tests/testthat/test-ohsome_boundary.R
+++ b/tests/testthat/test-ohsome_boundary.R
@@ -82,7 +82,12 @@ test_that("creates ohsome_boundary object from list of bboxes of various classes
 		"8.5992,49.3567,8.7499,49.4371",
 		"9.1638,49.113,9.2672,49.1766"
 	)
-	bboxes2 <- osmdata::getbb("Berlin")
+	# output of dput(osmdata::getbb("Berlin"))
+	bboxes2 <- structure(
+		c(13.088345, 52.3382448, 13.7611609, 52.6755087),
+		dim = c(2L, 2L),
+		dimnames = list(c("x", "y"), c("min", "max"))
+	)
 	bboxes3 <- sf::st_bbox(breweries)
 
 	b <- ohsome_boundary(list(bboxes1, bboxes2, bboxes3))

--- a/tests/testthat/test-ohsome_boundary.R
+++ b/tests/testthat/test-ohsome_boundary.R
@@ -67,12 +67,17 @@ test_that("throws error on sf with point geometries only", {
 })
 
 test_that("issues warning for sf boundaries that contain polygon and other geoms", {
+	
+	skip_if_not_installed("dplyr")
+	
 	mixed <- dplyr::bind_rows(franconia, breweries)
 	expect_warning(ohsome_boundary(mixed))
 })
 
 test_that("creates ohsome_boundary object from list of bboxes of various classes", {
-
+	
+	skip_if_not_installed("osmdata")
+	
 	bboxes1 <- c(
 		"8.5992,49.3567,8.7499,49.4371",
 		"9.1638,49.113,9.2672,49.1766"

--- a/vignettes/ohsome.Rmd
+++ b/vignettes/ohsome.Rmd
@@ -8,11 +8,14 @@ vignette: >
 ---
 
 ```{r, include = FALSE}
+NOT_CRAN <- identical(tolower(Sys.getenv("NOT_CRAN")), "true")
 knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>",
   fig.path = "figures/", 
-  out.width = "100%"
+  out.width = "100%",
+  purl = NOT_CRAN,
+  eval = NOT_CRAN
 )
 ```
 

--- a/vignettes/ohsome.Rmd
+++ b/vignettes/ohsome.Rmd
@@ -468,8 +468,7 @@ building_levels <- franconia |>
 dim(building_levels)
 ```
 
-The query results in a confusing data.frame with `r ncol(building_levels)` 
-columns and `r nrow(building_levels)` rows. This happens because there is a 
+The query results in a confusing data.frame. This happens because there is a 
 building count column for each combination of boundary polygon and number of 
 levels, while the two requested timestamps are in the rows. Fortunately, there 
 is the 

--- a/vignettes/ohsome.Rmd
+++ b/vignettes/ohsome.Rmd
@@ -9,6 +9,7 @@ vignette: >
 
 ```{r, include = FALSE}
 NOT_CRAN <- identical(tolower(Sys.getenv("NOT_CRAN")), "true")
+httr::set_config(httr::config(http_version = 1))
 knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>",


### PR DESCRIPTION
This patch introduces some changes to ensure compliance with CRAN policy:

* If the package cannot retrieve metadata from the ohsome API on startup, it now issues a message instead of a warning.
* Code chunks are not evaluated when the vignette is built on CRAN to avoid errors when internet resources are temporally unavailable or temporally produce unexpected responses.
* Tests are fixed to use suggested packages conditionally to avoid test failures when packages are not available.

Closes #15